### PR TITLE
Fixed function to create components node if missing

### DIFF
--- a/src/heron.py
+++ b/src/heron.py
@@ -40,15 +40,18 @@ def create_componentsets_in_HERON(comp_sets_folder, heron_input_xml):
 
   HERON_inp_tree = ET.parse(heron_input_xml)
   components_list = HERON_inp_tree.findall("Components")  # The "components" node
+  # if the "components" node is not found
   if not components_list:
-    print("\n", f"The 'Components' node is not found in the HERON input xml file: {heron_input_xml}")
-  else:
-    for components in components_list:
-      component = components.findall("Component")
-      heron_comp_list = []  # The list of compoenents
-      for comp in component:
-        heron_comp_list.append(comp.attrib["name"]) # The list of components found in the HERON input XML file
-      # print(f" \n The following components are already in the HERON input XML file:'{heron_comp_list}'")
+    print("\n", f"The 'Components' node is not found in the HERON input xml file {heron_input_xml} and a new 'Components' node is created")
+    new_comps_node = ET.SubElement(HERON_inp_tree.getroot(), 'Components')
+    components_list = [new_comps_node]
+
+  for components in components_list:
+    component = components.findall("Component")
+    heron_comp_list = []  # The list of components
+    for comp in component:
+      heron_comp_list.append(comp.attrib["name"]) # The list of components found in the HERON input XML file
+    # print(f" \n The following components are already in the HERON input XML file:'{heron_comp_list}'")
 
   comp_set_files_list = os.listdir(comp_sets_folder)
 

--- a/src/heron.py
+++ b/src/heron.py
@@ -31,9 +31,9 @@ from xml.etree import ElementTree as ET
 
 def create_componentsets_in_HERON(comp_sets_folder, heron_input_xml):
   """
-    Create/update components (componnet-sets) in HERON input file
+    Create/update components (component-sets) in HERON input file
     @ In, comp_sets_folder, str, The path of the folder that includes several files of the user-input files
-    These user-input files determine the components which will be grouped together in one set
+        These user-input files determine the components which will be grouped together in one set
     @ In, heron_input_xml, str, The path of the original HERON xml file at which components will be updated/created
     @ Out, HERON_inp_tree, xml.etree.ElementTree.ElementTree, the updated HERON inut file (XML tree)
   """
@@ -51,8 +51,7 @@ def create_componentsets_in_HERON(comp_sets_folder, heron_input_xml):
     heron_comp_list = []  # The list of components
     for comp in component:
       heron_comp_list.append(comp.attrib["name"]) # The list of components found in the HERON input XML file
-    # print(f" \n The following components are already in the HERON input XML file:'{heron_comp_list}'")
-
+    
   comp_set_files_list = os.listdir(comp_sets_folder)
 
   # Goin through the FORCE componentSets to extract relevant info


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#15 

##### What are the significant changes in functionality due to this change request?
When a HERON XML script containing no `<Components>` node is input to the `src/heron/create_componentsets_in_HERON()` function, the function now adds a new `<Components>` node. It also prints a message stating that the addition was made. This mirrors the function's behavior when dealing with input scripts that are missing `<economics>` or `<CashFlow>` nodes.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [x] 1. Review all computer code.
- [x] 2. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [x] 3. Automated Tests should pass, including run_tests, pylint, and manual building tests.
- [x] 4. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test.
- [x] 5. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [x] 6. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.

