### PR TITLE
Fix create compsets heron function 2

### DIFF
--- a/src/heron.py
+++ b/src/heron.py
@@ -59,9 +59,10 @@ def create_componentsets_in_HERON(comp_sets_folder, heron_input_xml):
     if textfile.startswith('componentSet') and (textfile.endswith('.json') or textfile.endswith('.txt')):
       textfile_path = comp_sets_folder+"/"+textfile
       try:
-        comp_set_dict = json.load(open(textfile_path))
+        with open(textfile_path) as textfile_opened:
+          comp_set_dict = json.load(textfile_opened)
       except json.JSONDecodeError as e:
-        raise ValueError(f"The content of {textfile_path} is not in proper JSON format and cannot be read")
+        raise ValueError(f"The content of {textfile_path} is not in proper JSON format and cannot be read") from e
       comp_set_name = comp_set_dict.get('Component Set Name')
 
       ref_driver = comp_set_dict.get('Reference Driver')

--- a/src/heron.py
+++ b/src/heron.py
@@ -56,9 +56,12 @@ def create_componentsets_in_HERON(comp_sets_folder, heron_input_xml):
 
   # Goin through the FORCE componentSets to extract relevant info
   for textfile in comp_set_files_list:
-    if textfile.startswith('componentSet'):
+    if textfile.startswith('componentSet') and (textfile.endswith('.json') or textfile.endswith('.txt')):
       textfile_path = comp_sets_folder+"/"+textfile
-      comp_set_dict = json.load(open(textfile_path))
+      try:
+        comp_set_dict = json.load(open(textfile_path))
+      except json.JSONDecodeError as e:
+        raise ValueError(f"The content of {textfile_path} is not in proper JSON format and cannot be read")
       comp_set_name = comp_set_dict.get('Component Set Name')
 
       ref_driver = comp_set_dict.get('Reference Driver')

--- a/src/heron.py
+++ b/src/heron.py
@@ -90,10 +90,13 @@ def create_componentsets_in_HERON(comp_sets_folder, heron_input_xml):
                         node.append(ET.Comment(f" Some of this component economic info are imported from: {textfile_path}"))
                         print("The 'cashflow' subnode is found too and is updated")
                         Cashflow_NODE_FOUND = "True"
+                        elements_to_update = []
                         for subsubnode in subnode:
                           if subsubnode.tag in ['reference_driver', 'reference_price', 'scaling_factor_x']:
-                            subnode.remove(subsubnode)
+                            elements_to_update.append(subsubnode)
                             print(f"WARNING: The value of the {subsubnode.tag} is updated.")
+                        for element in elements_to_update:
+                          subnode.remove(element)
                         new_cash_node = subnode
                         new_cash_node.append(ET.Comment(f" Some of this component cashFlow info are imported from: {textfile_path}"))
 

--- a/tests/integration_tests/Aspen_HERON_FullTest/gold/new_heron_input.xml
+++ b/tests/integration_tests/Aspen_HERON_FullTest/gold/new_heron_input.xml
@@ -49,9 +49,6 @@
           <driver>
             <Function method="capacity">functions</Function>
           </driver>
-          <reference_driver>
-            <fixed_value>10.0</fixed_value>
-          </reference_driver>
           <!-- Some of this component cashFlow info are imported from: Sets1//componentSet_pumps.txt-->
           <reference_driver>
             <fixed_value>2.74763868640817</fixed_value>

--- a/tests/integration_tests/HERON_update_withCompSets/gold/new_heron_input.xml
+++ b/tests/integration_tests/HERON_update_withCompSets/gold/new_heron_input.xml
@@ -181,9 +181,6 @@
           <driver>
             <variable>BOP2_capacity</variable>
           </driver>
-          <scaling_factor_x>
-            <fixed_value>0.692</fixed_value>
-          </scaling_factor_x>
           <!-- Some of this component cashFlow info are imported from: Sets1//componentSet_turbines.txt-->
           <reference_driver>
             <fixed_value>26.4222377835452</fixed_value>


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#17 #18

##### What are the significant changes in functionality due to this change request?
To address issue #17, the `src/heron/create_componentsets_in_HERON()` was updated such that CashFlow subnodes that need updating are no longer immediately removed within the for loop that iterates over all of the CashFlow's children. Instead, they are added to a list. An additional for loop is then run, iterating over the new list, to remove each CashFlow child node that needs to be updated.

The testing of the above change revealed an error in the `tests/integration_tests/HERON_update_withCompSets/gold/` `new_heron_input.xml` file. As described in issue #17, the gold file contains duplicate subnodes of a CashFlow (namely, two `<scaling_factor_x>` subnodes) instead of a single, updated version of the subnode.

To address issue #18, the line in the `create_componentsets_in_HERON()` function containing the `json.load()` function has been placed within a try/except statement. If the `json.load()` function fails to properly decode the file (e.g., the file is not correctly formatted as a JSON), the rather cryptic error it raises will be caught. Instead, a custom `ValueError` with a clearer explanation of the problem is raised. In addition, the conditional that filters which files in the input component sets folder the function attempts to read was updated. Now, only .json and .txt files in the input component sets folder are allowed past this filter, since all component set data should be in a file that is one of these two types.

To correct initial test failure: The same issue was present in the `tests/integration_tests/Aspen_HERON_FullTest/gold/ new_heron_input.xml` file as was present in the `HERON_update_withCompSets` gold file mentioned above. In this case, duplicate `<reference_driver>` nodes were present in the gold file.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 3. Automated Tests should pass, including run_tests, pylint, and manual building tests.
- [ ] 4. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test.
- [ ] 5. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 6. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.

