### PR TITLE
Code coverage with github action - final

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
       - run: pwd
       - run: WD=`(cd ../../.. && pwd)` && export RAVEN_LIBS_NAME="raven_libs_"`basename $WD` && ./initalize_tests.sh
-      - run: >
+      - run: > # The overhead time added by checking coverage is currently about 19-23%. Reducing the frequency of coverage checks may be preferable if this increases.
           source raven/scripts/establish_conda_env.sh --load &&
           ./check_py_coverage.sh &&
           COV_PCT=`coverage report --format=total` &&

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,8 +13,7 @@ jobs:
       - run: pwd
       - run: WD=`(cd ../../.. && pwd)` && export RAVEN_LIBS_NAME="raven_libs_"`basename $WD` && ./initalize_tests.sh
       - run: source raven/scripts/establish_conda_env.sh --load && ./check_py_coverage.sh
-      - run: COV_PCT=`coverage report --format=total`
-      - run: echo "::notice title=Coverage Summary::Code coverage for this repository is now $COV_PCT%. See 'coverage_results' in Artifacts for details."
+      - run: COV_EX=`which coverage` && COV_PCT=`$COV_EX report --format=total` && echo "::notice title=Coverage Summary::Code coverage for this repository is now $COV_PCT%. See 'coverage_results' in Artifacts for details."
       - name: Archive tests results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,10 +12,18 @@ jobs:
         uses: actions/checkout@v3
       - run: pwd
       - run: WD=`(cd ../../.. && pwd)` && export RAVEN_LIBS_NAME="raven_libs_"`basename $WD` && ./initalize_tests.sh
-      - run: source raven/scripts/establish_conda_env.sh --load && ./run_tests
-      - name: Archive
+      - run: source raven/scripts/establish_conda_env.sh --load && ./check_py_coverage.sh
+      - run: COV_PCT=`coverage report --format=total`
+      - run: echo "::notice title=Coverage Summary::Code coverage for this repository is now $COV_PCT%. See 'coverage_results' in Artifacts for details."
+      - name: Archive tests results
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: tests_results
           path: tests
+      - name: Archive coverage results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage_results
+          path: tests/coverage_html_report

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,8 +12,10 @@ jobs:
         uses: actions/checkout@v3
       - run: pwd
       - run: WD=`(cd ../../.. && pwd)` && export RAVEN_LIBS_NAME="raven_libs_"`basename $WD` && ./initalize_tests.sh
-      - run: source raven/scripts/establish_conda_env.sh --load && ./check_py_coverage.sh
-      - run: COV_EX=`which coverage` && COV_PCT=`$COV_EX report --format=total` && echo "::notice title=Coverage Summary::Code coverage for this repository is now $COV_PCT%. See 'coverage_results' in Artifacts for details."
+      - run: >
+        source raven/scripts/establish_conda_env.sh --load &&
+        ./check_py_coverage.sh && COV_PCT=`coverage report --format=total` &&
+        echo "::notice title=Coverage Summary::Code coverage for this repository is now $COV_PCT%. See 'coverage_results' in Artifacts for details."
       - name: Archive tests results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,9 +13,10 @@ jobs:
       - run: pwd
       - run: WD=`(cd ../../.. && pwd)` && export RAVEN_LIBS_NAME="raven_libs_"`basename $WD` && ./initalize_tests.sh
       - run: >
-        source raven/scripts/establish_conda_env.sh --load &&
-        ./check_py_coverage.sh && COV_PCT=`coverage report --format=total` &&
-        echo "::notice title=Coverage Summary::Code coverage for this repository is now $COV_PCT%. See 'coverage_results' in Artifacts for details."
+          source raven/scripts/establish_conda_env.sh --load &&
+          ./check_py_coverage.sh &&
+          COV_PCT=`coverage report --format=total` &&
+          echo "::notice title=Coverage Summary::Code coverage for this repository is now $COV_PCT%. See 'coverage_results' in Artifacts for details."
       - name: Archive tests results
         uses: actions/upload-artifact@v4
         if: always()

--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+BUILD_DIR=${BUILD_DIR:=$HOME/*/raven_libraries/build}
+INSTALL_DIR=${INSTALL_DIR:=$HOME/*/*/raven_libraries}
+PYTHON_CMD=${PYTHON_CMD:=python}
+JOBS=${JOBS:=1}
+mkdir -p $BUILD_DIR
+mkdir -p $INSTALL_DIR
+DOWNLOADER='curl -C - -L -O '
+SCRIPT_DIRNAME=`dirname $0`
+SCRIPT_DIR=`(cd $SCRIPT_DIRNAME; pwd)`
+
+ORIGPYTHONPATH="$PYTHONPATH"
+
+update_python_path ()
+{
+    if ls -d $INSTALL_DIR/lib/python*
+    then
+        export PYTHONPATH=`ls -d $INSTALL_DIR/lib/python*/site-packages/`:"$ORIGPYTHONPATH"
+    fi
+}
+
+update_python_path
+PATH=$INSTALL_DIR/bin:$PATH
+
+if which coverage
+then
+    echo coverage already available, skipping building it.
+else
+    if curl http://www.energy.gov > /dev/null
+    then
+       echo Successfully got data from the internet
+    else
+       echo Could not connect to internet
+    fi
+
+    cd $BUILD_DIR
+    #SHA256=56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1
+    $DOWNLOADER https://files.pythonhosted.org/packages/ef/05/31553dc038667012853d0a248b57987d8d70b2d67ea885605f87bcb1baba/coverage-7.5.4.tar.gz
+    tar -xvzf coverage-7.5.4.tar.gz
+    cd coverage-7.5.4
+    (unset CC CXX; $PYTHON_CMD setup.py install --prefix=$INSTALL_DIR)
+fi
+
+update_python_path
+
+cd $SCRIPT_DIR
+
+#coverage help run
+SRC_DIR=`(cd src && pwd)`
+
+source $SCRIPT_DIR/raven/scripts/establish_conda_env.sh --quiet --load
+# get display var
+DISPLAY_VAR=`(echo $DISPLAY)`
+# reset it
+export DISPLAY=
+
+EXTRA="--rcfile=$SRC_DIR/../tests/.coveragerc --source=$SRC_DIR --parallel-mode"
+export COVERAGE_FILE=`pwd`/.coverage
+
+coverage erase --rcfile="$SRC_DIR/../tests/.coveragerc"
+($SRC_DIR/../run_tests "$@" --python-command="coverage run $EXTRA " || echo run_test done but some tests failed)
+
+#get DISPLAY BACK
+DISPLAY=$DISPLAY_VAR
+
+## Go to the final directory and generate the html documents
+cd $SCRIPT_DIR/tests/
+pwd
+rm -f .cov_dirs
+for FILE in `find . -name '.coverage.*'`; do dirname $FILE; done | sort | uniq > .cov_dirs
+coverage combine `cat .cov_dirs`
+coverage html
+

--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-BUILD_DIR=${BUILD_DIR:=$HOME/*/raven_libraries/build}
-INSTALL_DIR=${INSTALL_DIR:=$HOME/*/*/raven_libraries}
+SCRIPT_DIRNAME=`dirname $0`
+SCRIPT_DIR=`(cd $SCRIPT_DIRNAME; pwd)`
+source $SCRIPT_DIR/raven/scripts/establish_conda_env.sh --quiet --load
+RAVEN_LIBS_PATH=`conda env list | awk -v rln="$RAVEN_LIBS_NAME" '$0 ~ rln {print $NF}'`
+BUILD_DIR=${BUILD_DIR:=$RAVEN_LIBS_PATH/build}
+INSTALL_DIR=${INSTALL_DIR:=$RAVEN_LIBS_PATH}
 PYTHON_CMD=${PYTHON_CMD:=python}
 JOBS=${JOBS:=1}
 mkdir -p $BUILD_DIR
 mkdir -p $INSTALL_DIR
 DOWNLOADER='curl -C - -L -O '
-SCRIPT_DIRNAME=`dirname $0`
-SCRIPT_DIR=`(cd $SCRIPT_DIRNAME; pwd)`
 
 ORIGPYTHONPATH="$PYTHONPATH"
 
@@ -48,7 +50,6 @@ cd $SCRIPT_DIR
 #coverage help run
 SRC_DIR=`(cd src && pwd)`
 
-source $SCRIPT_DIR/raven/scripts/establish_conda_env.sh --quiet --load
 # get display var
 DISPLAY_VAR=`(echo $DISPLAY)`
 # reset it

--- a/check_py_coverage.sh
+++ b/check_py_coverage.sh
@@ -55,20 +55,18 @@ DISPLAY_VAR=`(echo $DISPLAY)`
 # reset it
 export DISPLAY=
 
-EXTRA="--rcfile=$SRC_DIR/../tests/.coveragerc --source=$SRC_DIR --parallel-mode"
+export COVERAGE_RCFILE="$SRC_DIR/../tests/.coveragerc" # all coverage commands should automatically reference this file now
+EXTRA="--source=$SRC_DIR --parallel-mode"
 export COVERAGE_FILE=`pwd`/.coverage
 
-coverage erase --rcfile="$SRC_DIR/../tests/.coveragerc"
-($SRC_DIR/../run_tests "$@" --python-command="coverage run $EXTRA " || echo run_test done but some tests failed)
+coverage erase
+($SRC_DIR/../run_tests "$@" --python-command="coverage run $EXTRA " || echo run_tests done but some tests failed)
 
 #get DISPLAY BACK
 DISPLAY=$DISPLAY_VAR
 
-## Go to the final directory and generate the html documents
-cd $SCRIPT_DIR/tests/
+## Prepare data and generate the html documents
 pwd
-rm -f .cov_dirs
-for FILE in `find . -name '.coverage.*'`; do dirname $FILE; done | sort | uniq > .cov_dirs
-coverage combine `cat .cov_dirs`
+coverage combine
 coverage html
 

--- a/run_tests
+++ b/run_tests
@@ -75,17 +75,19 @@ FAILED=()
 echo
 echo "********************************************************************************"
 echo
-echo 'Running FORCE tests ...'
 
 case $TEST_SET in
     0)
-        TEST_DIR=tests/unit_tests
+        TEST_DIR=$SCRIPT_DIR/tests/unit_tests
+        echo Running FORCE unit tests from $TEST_DIR directory ...
         ;;
     1)
-        TEST_DIR=tests/integration_tests
+        TEST_DIR=$SCRIPT_DIR/tests/integration_tests
+        echo Running FORCE integration tests from $TEST_DIR directory ...
         ;;
     2)
-        TEST_DIR=tests
+        TEST_DIR=$SCRIPT_DIR/tests
+        echo Running FORCE unit and integration tests from $TEST_DIR directory ...
         ;;
 esac
     

--- a/run_tests
+++ b/run_tests
@@ -10,6 +10,7 @@ else
 fi
 SCRIPT_DIR=`(cd $SCRIPT_DIRNAME; pwd)`
 
+TEST_SET=2 # 0 for unit tests, 1 for integration tests, 2 for both
 
 # source read ravenrc script
 RAVEN_RC_SCRIPT=$SCRIPT_DIR/raven/scripts/read_ravenrc.sh
@@ -18,6 +19,25 @@ source $RAVEN_RC_SCRIPT
 
 # set up installation manager
 INSTALLATION_MANAGER=$(read_ravenrc "INSTALLATION_MANAGER")
+
+# read command-line arguments
+ARGS=()
+for A in "$@"; do
+    case $A in
+        --unit-tests)
+            TEST_SET=0
+            ;;
+        --integration-tests)
+            TEST_SET=1
+            ;;
+        --all-tests)
+            TEST_SET=2
+            ;;
+        *)
+            ARGS+=("$A")
+            ;;
+    esac
+done
 
 
 echo 'Loading libraries ...'
@@ -57,7 +77,19 @@ echo "**************************************************************************
 echo
 echo 'Running FORCE tests ...'
 
-$PYTHON_COMMAND $SCRIPT_DIR/raven/rook/main.py --config-file=$SCRIPT_DIR/developer_tools/rook.ini --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$RAVEN_DIR/../HERON/src/Testers "${ARGS[@]}"
+case $TEST_SET in
+    0)
+        TEST_DIR=tests/unit_tests
+        ;;
+    1)
+        TEST_DIR=tests/integration_tests
+        ;;
+    2)
+        TEST_DIR=tests
+        ;;
+esac
+    
+$PYTHON_COMMAND $SCRIPT_DIR/raven/rook/main.py --config-file=$SCRIPT_DIR/developer_tools/rook.ini --test-dir $TEST_DIR --testers-dir $RAVEN_DIR/scripts/TestHarness/testers,$RAVEN_DIR/../HERON/src/Testers "${ARGS[@]}"
 
 # store return codes individually (rc) and combined (ALL_PASS)
 rc=$?

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,0 +1,12 @@
+# .coveragerc to control coverage.py
+
+[run]
+#branch = True
+parallel = True
+
+[report]
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -5,6 +5,27 @@
 parallel = True
 
 [report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    #def __repr__
+    #if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    raise IOError
+    raise Exception
+
+    # Don't complain for the things under development
+    pragma: under development
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
 
 ignore_errors = True
 

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -30,4 +30,4 @@ exclude_lines =
 ignore_errors = True
 
 [html]
-directory = coverage_html_report
+directory = tests/coverage_html_report


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
#23 

##### What are the significant changes in functionality due to this change request?
The `run_tests` shell script has been updated with a new feature. It now accepts a command line argument specifying which tests the user would like to run (unit, integration, or both). It defaults to running all tests. This feature is particularly useful when the user wishes to check the code coverage provided by a single test type.

A code coverage script named `check_py_coverage.sh` has been added. This script checks code coverage for all python files within the `FORCE/src` directory when `run_tests` is executed, and it returns the results in HTML format. It passes all command line arguments on to `run_tests`, thus preserving the functionality of arguments supported by `run_tests`. It is based on a similar script of the same name in the github.com/idaholab/raven repository. A config file for `coverage.py` has also been added.

The `run_tests.yml` script in the github action has been updated to run the above mentioned `check_py_coverage.sh` instead of the `run_tests` shell script. The coverage script serves as a wrapper around `run_tests`, so all tests are still run, albeit with some overhead time attributable to the coverage tracking. The coverage results are specifically exported to an artifact, where details regarding coverage can be found. A "notice" annotation has been added that alerts the user of the overall coverage of the tests in a more obvious manner than the artifact. The attached message also directs the user to the coverage artifact for more detailed coverage information.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 3. Automated Tests should pass, including run_tests, pylint, and manual building tests.
- [ ] 4. If significant functionality is added, there must be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test.
- [ ] 5. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 6. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.

